### PR TITLE
## Fix filename extraction and add JSON file support for Viedoc export script

### DIFF
--- a/viedoc-export/README.md
+++ b/viedoc-export/README.md
@@ -1,6 +1,6 @@
 # Viedoc Export Script
 
-These Python and R scripts triggers and downloads exports from Viedoc EDC. They include functionalities to:
+These Python and R scripts trigger and download exports from Viedoc EDC. They include functionalities to:
 - Authenticate and obtain an access token.
 - Initiate the export process.
 - Check the status of the export.
@@ -19,12 +19,16 @@ pip install requests
 Run:
 
 ```sh
-python viedoc_export.py --token_url <TOKEN_URL> --api_url <API_URL> --client_id <CLIENT_ID> --client_secret <CLIENT_SECRET> --export_model <EXPORT_MODEL> [--output_path <OUTPUT_PATH>][--extract_zip Y/N] [--remove_prefix Y/N]
+python viedoc_export.py --token_url <TOKEN_URL> --api_url <API_URL> --client_id <CLIENT_ID> --client_secret <CLIENT_SECRET> --export_model <EXPORT_MODEL_OR_JSON_FILE> [--output_path <OUTPUT_DIR>] [--extract_zip Y/N] [--remove_prefix Y/N]
 ```
-Example:
+Examples:
 
 ```sh
 python viedoc_export.py --token_url "https://v4ststraining.viedoc.net/connect/token" --api_url "https://v4apitraining.viedoc.net" --client_id "84731234-1234-1234-1234-1234cf658d98" --client_secret "FAaaTZaxxxxxxxxxxxxxxxxxxxxxxJzfw" --export_model '{"outputFormat":"CSV","includeVisitDates":true}'
+```
+
+```sh
+python viedoc_export.py --token_url "https://v4ststraining.viedoc.net/connect/token" --api_url "https://v4apitraining.viedoc.net" --client_id "84731234-1234-1234-1234-1234cf658d98" --client_secret "FAaaTZaxxxxxxxxxxxxxxxxxxxxxxJzfw" --export_model export_model.example.json --output_path "C:/Users/<you>/ViedocExports"
 ```
 
 - For R:
@@ -50,11 +54,14 @@ Rscript viedoc_export.R --token_url "https://v4ststraining.viedoc.net/connect/to
 - --api_url: Base URL for the Viedoc API.
 - --client_id: Client ID for authentication.
 - --client_secret: Client secret for authentication.
-- --export_model: JSON string representing the export model. Ex. 
-
-```
-{"outputFormat":"CSV","includeVisitDates":false,"includeEditStatus":false,"includeSignatures":false,"includeReviewStatus":false,"includeSdv":false,"includeQueries":false,"includeQueryHistory":false,"includeSubjectStatus":false,"includePendingForms":false}"
-```
-
+- --export_model: Inline JSON, a JSON file path, or `@path/to/file.json`. For less error-prone runs, start from [export_model.example.json](./export_model.example.json).
+- --output_path: Output directory. Defaults to `out`.
 - --extract_zip: (Optional) Extract the zip file if set to Y. Default is Y.
-- --remove_prefix: (Optional) Remove the prefix from extracted files if set to Y. Default is Y.
+- --remove_prefix: (Optional) Remove the download filename prefix from extracted files if set to Y. Default is Y.
+- --timeout_seconds: (Optional) Per-request timeout. Default is 60.
+- --poll_interval_seconds: (Optional) Seconds between export status checks. Default is 10.
+- --max_wait_seconds: (Optional) Maximum total wait time for the export to become ready. Default is 600.
+
+```
+{"outputFormat":"CSV","includeVisitDates":false,"includeEditStatus":false,"includeSignatures":false,"includeReviewStatus":false,"includeSdv":false,"includeQueries":false,"includeQueryHistory":false,"includeSubjectStatus":false,"includePendingForms":false}
+```

--- a/viedoc-export/README.md
+++ b/viedoc-export/README.md
@@ -1,103 +1,159 @@
-# Viedoc Export Script
+# Viedoc Export Python Script
 
-These Python and R scripts trigger and download exports from Viedoc EDC. They include functionalities to:
-- Authenticate and obtain an access token.
-- Initiate the export process.
-- Check the status of the export.
-- Download and optionally extract the exported files.
+This script:
+- gets an access token
+- starts a Viedoc export
+- polls until the export is ready
+- downloads the result into the `out` directory
+- extracts zip exports by default
 
-## Usage
-To run the Viedoc Export Script, use the following command:
+Run commands from the `viedoc-export` directory.
 
-- For python: 
+## Tested Scope
 
-Install dependencies
+Checked in this repo on Windows on April 27, 2026:
+- `pip install requests`
+- `python viedoc_export.py --help`
+- PowerShell run examples against the stage API
+- `cmd.exe` run examples against the stage API
+- `py -m venv .venv` was attempted, but this Microsoft Store Python installation created a partial environment without activation scripts or `pip`
 
-```sh
+Bash examples below use standard Unix shell syntax for Linux/macOS.
+
+## Supported Arguments
+
+| Argument | Description | Required |
+|----------|-------------|----------|
+| `--token_url` | Token endpoint | Yes |
+| `--api_url` | Viedoc API base URL | Yes |
+| `--client_id` | Client ID | Yes |
+| `--client_secret` | Client secret | Yes |
+| `--export_model` | Inline JSON or `.json` file path | No |
+| `--extract_zip` | `Y` or `N` | No |
+| `--remove_prefix` | `Y` or `N` | No |
+
+If `--export_model` is omitted, the script loads [`export_model.example.json`](./export_model.example.json).
+
+## Virtual Environment Setup
+
+These are the standard `venv` commands. In this Windows environment, `py -m venv .venv` did not complete cleanly, so prefer an existing environment or a non-Microsoft-Store Python install if you need a fresh virtual environment here.
+
+### Bash on Linux/macOS
+
+Create and activate a virtual environment:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install requests
+```
+
+### Windows PowerShell
+
+Create and activate a virtual environment:
+
+```powershell
+py -m venv .venv
+.\.venv\Scripts\Activate.ps1
+python -m pip install --upgrade pip
+python -m pip install requests
+```
+
+If script activation is blocked, use:
+
+```powershell
+Set-ExecutionPolicy -Scope Process Bypass
+.\.venv\Scripts\Activate.ps1
+```
+
+### Windows `cmd.exe`
+
+Create and activate a virtual environment:
+
+```cmd
+py -m venv .venv
+.\.venv\Scripts\activate.bat
+python -m pip install --upgrade pip
+python -m pip install requests
+```
+
+### Without a Virtual Environment
+
+```powershell
 pip install requests
 ```
-Run:
 
-```sh
-python viedoc_export.py --token_url <TOKEN_URL> --api_url <API_URL> --client_id <CLIENT_ID> --client_secret <CLIENT_SECRET> --export_model <EXPORT_MODEL_OR_JSON_FILE> [--output_path <OUTPUT_DIR>] [--extract_zip Y/N] [--remove_prefix Y/N]
-```
-Examples:
+## Usage
 
-```sh
-python viedoc_export.py --token_url "https://v4ststraining.viedoc.net/connect/token" --api_url "https://v4apitraining.viedoc.net" --client_id "84731234-1234-1234-1234-1234cf658d98" --client_secret "FAaaTZaxxxxxxxxxxxxxxxxxxxxxxJzfw" --export_model '{"outputFormat":"CSV","includeVisitDates":true}'
+General form:
+
+```text
+python viedoc_export.py --token_url <TOKEN_URL> --api_url <API_URL> --client_id <CLIENT_ID> --client_secret <CLIENT_SECRET> [--export_model <INLINE_JSON_OR_JSON_FILE>] [--extract_zip Y|N] [--remove_prefix Y|N]
 ```
 
-```sh
-python viedoc_export.py --token_url "https://v4ststraining.viedoc.net/connect/token" --api_url "https://v4apitraining.viedoc.net" --client_id "84731234-1234-1234-1234-1234cf658d98" --client_secret "FAaaTZaxxxxxxxxxxxxxxxxxxxxxxJzfw" --export_model @export_model.example.json --output_path "C:/Users/<you>/ViedocExports"
+## Export Model Behavior
+
+- If the `--export_model` value ends with `.json`, the script treats it as a file path
+- Relative `.json` paths are resolved from the current directory first, then from the script directory
+- Any non-`.json` value is treated as inline JSON
+- Using a `.json` file is the safest option across shells
+
+## Bash Examples (Unix OS e.g. Linux or MacOS)
+
+Use the bundled example file:
+
+```bash
+python3 viedoc_export.py --token_url "https://v4ststraining.viedoc.net/connect/token" --api_url "https://v4apitraining.viedoc.net" --client_id "your-client-id" --client_secret "your-client-secret" --export_model ./export_model.example.json
 ```
 
-- For R:
+Use the default bundled example file by omitting `--export_model`:
 
-Install dependencies:
-
-```sh
-Rscript -e 'install.packages(c("httr", "jsonlite", "logging", "argparse", "stringr", "tools", "zip"), repos = "https://cran.r-project.org")'
-```
-Run: 
-
-```sh
-Rscript viedoc_export.R --token_url <TOKEN_URL> --api_url <API_URL> --client_id <CLIENT_ID> --client_secret <CLIENT_SECRET> --export_model <EXPORT_MODEL> [--output_path <OUTPUT_PATH>] [--extract_zip Y/N] [--remove_prefix Y/N]
+```bash
+python3 viedoc_export.py --token_url "https://v4ststraining.viedoc.net/connect/token" --api_url "https://v4apitraining.viedoc.net" --client_id "your-client-id" --client_secret "your-client-secret"
 ```
 
-Example:
-```sh
-Rscript viedoc_export.R --token_url "https://v4ststraining.viedoc.net/connect/token" --api_url "https://v4apitraining.viedoc.net" --client_id "84731234-1234-1234-1234-1234cf658d98" --client_secret "FAaaTZaxxxxxxxxxxxxxxxxxxxxxxJzfw" --export_model '{"outputFormat":"CSV","includeVisitDates":true}'
-```sh
+Pass inline JSON:
 
-## Arguments:
-- --token_url: URL to get the authentication token.
-- --api_url: Base URL for the Viedoc API.
-- --client_id: Client ID for authentication.
-- --client_secret: Client secret for authentication.
-- --export_model: Inline JSON, a JSON file path, or `@path/to/file.json`. For less error-prone runs, start from [export_model.example.json](./export_model.example.json).
-- --output_path: Output directory. Defaults to `out`.
-- --extract_zip: (Optional) Extract the zip file if set to Y. Default is Y.
-- --remove_prefix: (Optional) Remove the download filename prefix from extracted files if set to Y. Default is Y.
-- --timeout_seconds: (Optional) Per-request timeout. Default is 60.
-- --poll_interval_seconds: (Optional) Seconds between export status checks. Default is 10.
-- --max_wait_seconds: (Optional) Maximum total wait time for the export to become ready. Default is 600.
-
-### Shell Quoting Notes
-
-The `--export_model` parameter accepts JSON. Proper quoting depends on your shell:
-
-**Linux/macOS (bash/zsh):**
-```sh
-python viedoc_export.py ... --export_model '{"outputFormat":"CSV"}'
+```bash
+python3 viedoc_export.py --token_url "https://v4ststraining.viedoc.net/connect/token" --api_url "https://v4apitraining.viedoc.net" --client_id "your-client-id" --client_secret "your-client-secret" --export_model '{"outputFormat":"CSV","includeVisitDates":true}'
 ```
-Use single quotes to preserve double quotes in the JSON.
 
-**Windows (PowerShell):**
+## PowerShell Examples
+
+Use the bundled example file:
+
 ```powershell
-python viedoc_export.py ... --export_model '{\"outputFormat\":\"CSV\"}'
-```
-Escape inner double quotes with backslashes, or use:
-```powershell
-python viedoc_export.py ... --export_model "{'outputFormat':'CSV'}"
+python viedoc_export.py --token_url "https://v4ststraining.viedoc.net/connect/token" --api_url "https://v4apitraining.viedoc.net" --client_id "your-client-id" --client_secret "your-client-secret" --export_model .\export_model.example.json
 ```
 
-**Windows (cmd.exe):**
+Use the default bundled example file by omitting `--export_model`:
+
+```powershell
+python viedoc_export.py --token_url "https://v4ststraining.viedoc.net/connect/token" --api_url "https://v4apitraining.viedoc.net" --client_id "your-client-id" --client_secret "your-client-secret"
+```
+
+Pass inline JSON:
+
+```powershell
+python viedoc_export.py --token_url "https://v4ststraining.viedoc.net/connect/token" --api_url "https://v4apitraining.viedoc.net" --client_id "your-client-id" --client_secret "your-client-secret" --export_model '{\"outputFormat\":\"CSV\",\"includeVisitDates\":true}'
+```
+
+## `cmd.exe` Examples
+
+Use the bundled example file:
+
 ```cmd
-python viedoc_export.py ... --export_model "{\"outputFormat\":\"CSV\"}"
-```
-Escape inner double quotes with backslashes.
-
-**Recommended approach (all platforms):**
-Use a JSON file to avoid quoting issues entirely:
-```sh
-python viedoc_export.py ... --export_model export_model.json
-```
-or
-```sh
-python viedoc_export.py ... --export_model @export_model.json
+python viedoc_export.py --token_url "https://v4ststraining.viedoc.net/connect/token" --api_url "https://v4apitraining.viedoc.net" --client_id "your-client-id" --client_secret "your-client-secret" --export_model .\export_model.example.json
 ```
 
-Example JSON file:
+Pass inline JSON:
+
+```cmd
+python viedoc_export.py --token_url "https://v4ststraining.viedoc.net/connect/token" --api_url "https://v4apitraining.viedoc.net" --client_id "your-client-id" --client_secret "your-client-secret" --export_model "{\"outputFormat\":\"CSV\"}"
 ```
-{"outputFormat":"CSV","includeVisitDates":false,"includeEditStatus":false,"includeSignatures":false,"includeReviewStatus":false,"includeSdv":false,"includeQueries":false,"includeQueryHistory":false,"includeSubjectStatus":false,"includePendingForms":false}
-```
+
+## Output
+
+- Files are written to the `out` directory under the current working directory
+- There is no `--output_path` argument in `viedoc_export.py` so output path cannot be customised

--- a/viedoc-export/README.md
+++ b/viedoc-export/README.md
@@ -28,7 +28,7 @@ python viedoc_export.py --token_url "https://v4ststraining.viedoc.net/connect/to
 ```
 
 ```sh
-python viedoc_export.py --token_url "https://v4ststraining.viedoc.net/connect/token" --api_url "https://v4apitraining.viedoc.net" --client_id "84731234-1234-1234-1234-1234cf658d98" --client_secret "FAaaTZaxxxxxxxxxxxxxxxxxxxxxxJzfw" --export_model export_model.example.json --output_path "C:/Users/<you>/ViedocExports"
+python viedoc_export.py --token_url "https://v4ststraining.viedoc.net/connect/token" --api_url "https://v4apitraining.viedoc.net" --client_id "84731234-1234-1234-1234-1234cf658d98" --client_secret "FAaaTZaxxxxxxxxxxxxxxxxxxxxxxJzfw" --export_model @export_model.example.json --output_path "C:/Users/<you>/ViedocExports"
 ```
 
 - For R:
@@ -62,6 +62,42 @@ Rscript viedoc_export.R --token_url "https://v4ststraining.viedoc.net/connect/to
 - --poll_interval_seconds: (Optional) Seconds between export status checks. Default is 10.
 - --max_wait_seconds: (Optional) Maximum total wait time for the export to become ready. Default is 600.
 
+### Shell Quoting Notes
+
+The `--export_model` parameter accepts JSON. Proper quoting depends on your shell:
+
+**Linux/macOS (bash/zsh):**
+```sh
+python viedoc_export.py ... --export_model '{"outputFormat":"CSV"}'
+```
+Use single quotes to preserve double quotes in the JSON.
+
+**Windows (PowerShell):**
+```powershell
+python viedoc_export.py ... --export_model '{\"outputFormat\":\"CSV\"}'
+```
+Escape inner double quotes with backslashes, or use:
+```powershell
+python viedoc_export.py ... --export_model "{'outputFormat':'CSV'}"
+```
+
+**Windows (cmd.exe):**
+```cmd
+python viedoc_export.py ... --export_model "{\"outputFormat\":\"CSV\"}"
+```
+Escape inner double quotes with backslashes.
+
+**Recommended approach (all platforms):**
+Use a JSON file to avoid quoting issues entirely:
+```sh
+python viedoc_export.py ... --export_model export_model.json
+```
+or
+```sh
+python viedoc_export.py ... --export_model @export_model.json
+```
+
+Example JSON file:
 ```
 {"outputFormat":"CSV","includeVisitDates":false,"includeEditStatus":false,"includeSignatures":false,"includeReviewStatus":false,"includeSdv":false,"includeQueries":false,"includeQueryHistory":false,"includeSubjectStatus":false,"includePendingForms":false}
 ```

--- a/viedoc-export/export_model.example.json
+++ b/viedoc-export/export_model.example.json
@@ -1,0 +1,12 @@
+{
+  "outputFormat": "CSV",
+  "includeVisitDates": true,
+  "includeEditStatus": true,
+  "includeSignatures": true,
+  "includeReviewStatus": true,
+  "includeSdv": true,
+  "includeQueries": true,
+  "includeQueryHistory": true,
+  "includeSubjectStatus": true,
+  "includePendingForms": true
+}

--- a/viedoc-export/viedoc_export.py
+++ b/viedoc-export/viedoc_export.py
@@ -10,25 +10,45 @@ import logging  # For logging information
 # Configure logging to display info messages with a specific format
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+DEFAULT_EXPORT_MODEL_PATH = os.path.join(SCRIPT_DIR, "export_model.example.json")
+
+
 def load_export_model(export_model_input):
     """
     Load export model from a file or use the provided string.
     
     Args:
-    - export_model_input (str): Either a JSON string or a file path starting with '@'
+    - export_model_input (str): Either a file path or inline JSON string
     
     Returns:
     - str: JSON string representing the export model
     """
-    if export_model_input.startswith("@"):
-        # Load from file
-        file_path = export_model_input[1:]
-        logging.info("Loading export model from file: %s", file_path)
-        with open(file_path, 'r', encoding='utf-8') as f:
-            return f.read()
-    else:
-        # Treat as inline JSON
+    if not export_model_input:
+        logging.info("No export model provided. Using default file: %s", DEFAULT_EXPORT_MODEL_PATH)
+        export_model_input = DEFAULT_EXPORT_MODEL_PATH
+    
+    if not export_model_input.endswith(".json"):
         return export_model_input
+    
+    candidate_paths = [export_model_input]
+    file_path = None
+
+    if not os.path.isabs(export_model_input):
+        candidate_paths.append(os.path.join(SCRIPT_DIR, export_model_input))
+
+    for path in candidate_paths:
+        if os.path.isfile(path):
+            file_path = path
+    if not file_path:
+        checked_paths = ", ".join(candidate_paths)
+        raise FileNotFoundError(f"Export model file not found. Checked: {checked_paths}")
+    logging.info("Loading export model from file: %s", file_path)
+    with open(file_path, 'r', encoding='utf-8') as f:
+        json_data = json.load(f)
+
+    # Treat as inline JSON
+    return json.dumps(json_data)
 
 def get_token(url, client_id, client_secret):
     """
@@ -211,7 +231,15 @@ if __name__ == "__main__":
     parser.add_argument("--api_url", required=True, help="API URL")
     parser.add_argument("--client_id", required=True, help="Client ID")
     parser.add_argument("--client_secret", required=True, help="Client secret")
-    parser.add_argument("--export_model", required=True, help="Inline JSON or a file path starting with @ (e.g., @export_model.json)")
+    parser.add_argument(
+        "--export_model",
+        required=False,
+        default=None,
+        help=(
+            "Inline JSON or a JSON file path. PowerShell users should pass a plain path "
+            "(for example, export_model.example.json). Defaults to the bundled example file."
+        ),
+    )
     parser.add_argument("--extract_zip", required=False, default="Y", choices=["Y", "N"], help="Extract zip file (Y/N)")
     parser.add_argument("--remove_prefix", required=False, default="Y", choices=["Y", "N"], help="Remove prefix from extracted files (Y/N)")
 

--- a/viedoc-export/viedoc_export.py
+++ b/viedoc-export/viedoc_export.py
@@ -1,439 +1,221 @@
-"""Single-study Viedoc data export helper."""
+import argparse  # For parsing command-line arguments
+import io  # For handling byte streams
+import json  # For JSON parsing
+import zipfile  # For handling zip files
+import requests  # For making HTTP requests
+import time  # For adding delays
+import os  # For file and directory operations
+import logging  # For logging information
 
-from __future__ import annotations
+# Configure logging to display info messages with a specific format
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
-import argparse
-import io
-import json
-import logging
-import shutil
-import time
-import urllib.parse
-import zipfile
-from pathlib import Path
-from typing import TYPE_CHECKING, Any
-
-if TYPE_CHECKING:
-    import requests as requests_module
-
-try:
-    import requests
-except ImportError as exc:  # pragma: no cover - dependency validation only
-    requests = None  # type: ignore[assignment]
-    REQUESTS_IMPORT_ERROR = exc
-else:
-    REQUESTS_IMPORT_ERROR = None
-
-
-LOGGER = logging.getLogger("viedoc_export")
-DEFAULT_OUTPUT_DIR = Path("out")
-DEFAULT_TIMEOUT_SECONDS = 60
-DEFAULT_POLL_INTERVAL_SECONDS = 10
-DEFAULT_MAX_WAIT_SECONDS = 600
-
-
-def configure_logging(level: str) -> None:
-    logging.basicConfig(
-        level=getattr(logging, level.upper(), logging.INFO),
-        format="%(asctime)s - %(levelname)s - %(message)s",
-    )
-
-
-def mask_value(value: str, visible_prefix: int = 3) -> str:
-    if not value:
-        return "***"
-    if len(value) <= visible_prefix:
-        return "*" * len(value)
-    return value[:visible_prefix] + "*" * (len(value) - visible_prefix)
-
-
-def parse_export_model(raw_value: str) -> dict[str, Any]:
-    candidate = raw_value.strip()
-    file_path_text = candidate[1:] if candidate.startswith("@") else candidate
-    file_path = Path(file_path_text)
-
-    if file_path.is_file():
-        LOGGER.info("Reading export model from %s", file_path)
-        content = file_path.read_text(encoding="utf-8")
+def load_export_model(export_model_input):
+    """
+    Load export model from a file or use the provided string.
+    
+    Args:
+    - export_model_input (str): Either a JSON string or a file path starting with '@'
+    
+    Returns:
+    - str: JSON string representing the export model
+    """
+    if export_model_input.startswith("@"):
+        # Load from file
+        file_path = export_model_input[1:]
+        logging.info("Loading export model from file: %s", file_path)
+        with open(file_path, 'r', encoding='utf-8') as f:
+            return f.read()
     else:
-        content = candidate
+        # Treat as inline JSON
+        return export_model_input
 
-    try:
-        parsed = json.loads(content)
-    except json.JSONDecodeError as exc:
-        raise ValueError(
-            "Invalid export model JSON. Pass inline JSON or a path to a JSON file."
-        ) from exc
-
-    if not isinstance(parsed, dict):
-        raise ValueError("The export model must decode to a JSON object.")
-
-    return parsed
-
-
-def extract_filename(content_disposition: str | None, export_id: str) -> str:
-    if not content_disposition:
-        return f"viedoc_export_{export_id}"
-
-    filename_star = "filename*="
-    if filename_star in content_disposition:
-        fragment = content_disposition.split(filename_star, 1)[1].split(";", 1)[0].strip()
-        if "''" in fragment:
-            _, encoded_name = fragment.split("''", 1)
-        else:
-            encoded_name = fragment
-        decoded_name = urllib.parse.unquote(encoded_name.strip('"'))
-        if decoded_name:
-            return Path(decoded_name).name
-
-    filename_key = "filename="
-    if filename_key in content_disposition:
-        fragment = content_disposition.split(filename_key, 1)[1].split(";", 1)[0].strip()
-        decoded_name = fragment.strip('"')
-        if decoded_name:
-            return Path(decoded_name).name
-
-    return f"viedoc_export_{export_id}"
-
-
-def move_path_contents(source_dir: Path, destination_dir: Path) -> None:
-    for child in source_dir.iterdir():
-        target = destination_dir / child.name
-        if target.exists():
-            if target.is_dir():
-                shutil.rmtree(target)
-            else:
-                target.unlink()
-        shutil.move(str(child), str(target))
-    source_dir.rmdir()
-
-
-def remove_extracted_prefix(output_dir: Path, zip_stem: str, archive_members: list[str]) -> None:
-    if not zip_stem:
-        return
-
-    top_level_members = {
-        Path(member).parts[0]
-        for member in archive_members
-        if member and not member.endswith("/")
+def get_token(url, client_id, client_secret):
+    """
+    Request an access token from the authentication server.
+    
+    Args:
+    - url (str): URL to get the token from.
+    - client_id (str): Client ID for authentication.
+    - client_secret (str): Client secret for authentication.
+    
+    Returns:
+    - str: Access token.
+    """
+    logging.info("Getting token...")
+    payload = {
+        "grant_type": "client_credentials",
+        "client_id": client_id,
+        "client_secret": client_secret
     }
+    response = requests.post(url, data=payload)
+    response.raise_for_status()  # Raise an exception for HTTP errors
+    return response.json()["access_token"]
 
-    for member_name in sorted(top_level_members, key=len, reverse=True):
-        source = output_dir / member_name
-        if not source.exists():
-            continue
+def start_export(url, token, export_model):
+    """
+    Start the export process.
 
-        if member_name == zip_stem and source.is_dir():
-            move_path_contents(source, output_dir)
-            continue
+    Args:
+    - url (str): URL to start the export.
+    - token (str): Access token for authorization.
+    - export_model (str): JSON string representing the export model.
+    
+    Returns:
+    - str: Export ID.
+    """
+    logging.info("Starting export...")
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    response = requests.post(url, headers=headers, data=export_model)
+    
+    if response.status_code > 399:
+        logging.info("Error: %s", response.text)
+        response.raise_for_status()  # Raise an exception for HTTP errors
+    
+    return response.json()["exportId"]
 
-        if not member_name.startswith(zip_stem):
-            continue
+def check_export_status(url, token, export_id):
+    """
+    Check the status of the export until it's ready.
 
-        trimmed_name = member_name[len(zip_stem) :].lstrip(" _-.")
-        if not trimmed_name:
-            continue
+    Args:
+    - url (str): URL to check the export status.
+    - token (str): Access token for authorization.
+    - export_id (str): ID of the export to check.
+    """
+    logging.info("Checking export status...")
+    headers = {"Authorization": f"Bearer {token}"}
+    while True:
+        response = requests.get(f"{url}?exportId={export_id}", headers=headers)
+        response.raise_for_status()  # Raise an exception for HTTP errors
+        status = response.json()["exportStatus"]
 
-        target = output_dir / trimmed_name
-        if target.exists():
-            if target.is_dir():
-                shutil.rmtree(target)
-            else:
-                target.unlink()
-        source.replace(target)
+        logging.info("Export status: %s", status)
 
+        if status == "Error":
+            raise Exception("Export failed")  # Raise an exception if the export failed
 
-class ViedocExportClient:
-    def __init__(
-        self,
-        *,
-        token_url: str,
-        api_url: str,
-        client_id: str,
-        client_secret: str,
-        timeout_seconds: int,
-    ) -> None:
-        self.token_url = token_url
-        self.api_url = api_url.rstrip("/")
-        self.client_id = client_id
-        self.client_secret = client_secret
-        self.timeout_seconds = timeout_seconds
-        self.session = requests.Session()
-        self._token: str | None = None
+        if status == "Ready":
+            return  # Exit the loop if the export is ready
+        logging.info("Sleeping...")
+        time.sleep(10)  # Wait for 10 seconds before checking again
 
-    def _fetch_token(self) -> str:
-        LOGGER.info("Requesting access token from %s", self.token_url)
-        response = self.session.post(
-            self.token_url,
-            data={
-                "grant_type": "client_credentials",
-                "client_id": self.client_id,
-                "client_secret": self.client_secret,
-            },
-            timeout=self.timeout_seconds,
-        )
-        self._raise_for_status("token request", self.token_url, response)
+def download_export(url, token, export_id, extract_zip, remove_prefix):
+    """
+    Download the export file and optionally extract it.
 
-        payload = response.json()
-        token = payload.get("access_token") if isinstance(payload, dict) else None
-        if not token:
-            raise RuntimeError("Token response did not include 'access_token'.")
+    Args:
+    - url (str): URL to download the export.
+    - token (str): Access token for authorization.
+    - export_id (str): ID of the export to download.
+    - extract_zip (bool): Whether to extract the zip file.
+    - remove_prefix (bool): Whether to remove the prefix from extracted files.
+    """
+    headers = {"Authorization": f"Bearer {token}"}
+    response = requests.get(f"{url}?exportId={export_id}", headers=headers)
+    response.raise_for_status()  # Raise an exception for HTTP errors
 
-        self._token = str(token)
-        return self._token
+    # Extract the filename from the Content-Disposition header
+    content_disposition_header = response.headers.get("Content-Disposition")
+    filename = "UNKNOWN_FILENAME"
+    if content_disposition_header and "filename=" in content_disposition_header:
+        # Use split instead of regex to handle Content-Disposition with both filename= and filename*= headers
+        filename = content_disposition_header.split("filename=")[1].split(";")[0].strip().strip('"')
 
-    def _request_with_auth(
-        self,
-        method: str,
-        url: str,
-        action: str,
-        **kwargs: Any,
-    ) -> "requests_module.Response":
-        for attempt in (1, 2):
-            token = self._token or self._fetch_token()
-            headers = dict(kwargs.pop("headers", {}))
-            headers["Authorization"] = f"Bearer {token}"
-            response = self.session.request(
-                method,
-                url,
-                headers=headers,
-                timeout=self.timeout_seconds,
-                **kwargs,
-            )
-            if response.status_code != 401 or attempt == 2:
-                return response
+    # Create the 'out' folder if it doesn't exist
+    if not os.path.exists("out"):
+        os.makedirs("out")
 
-            LOGGER.warning("%s returned 401. Refreshing token and retrying once.", action)
-            self._token = None
+    folder_path = "out"
 
-        raise RuntimeError("Unreachable auth retry state.")
+    logging.info("Folder path: %s", folder_path)
 
-    @staticmethod
-    def _raise_for_status(action: str, url: str, response: "requests_module.Response") -> None:
-        try:
-            response.raise_for_status()
-        except requests.HTTPError as exc:
-            details = response.text.strip()
-            raise RuntimeError(
-                f"{action} failed for {url} with status {response.status_code}: {details}"
-            ) from exc
+    # If the filename is .zip and extract_zip is True, extract the file
+    if filename.endswith(".zip") and extract_zip:
+        logging.info("Extracting zip file...")
+        with zipfile.ZipFile(io.BytesIO(response.content)) as z:
+            z.extractall(folder_path)
+        logging.info("File extracted successfully!")
 
-    def start_export(self, export_model: dict[str, Any]) -> str:
-        url = f"{self.api_url}/clinic/dataexport/start"
-        LOGGER.info("Starting export at %s", url)
-        response = self._request_with_auth(
-            "POST",
-            url,
-            "start export",
-            headers={"Content-Type": "application/json"},
-            json=export_model,
-        )
-        self._raise_for_status("start export", url, response)
-
-        payload = response.json()
-        export_id = payload.get("exportId") if isinstance(payload, dict) else None
-        if not export_id:
-            raise RuntimeError("Export start response did not include 'exportId'.")
-        return str(export_id)
-
-    def wait_for_export(
-        self,
-        export_id: str,
-        *,
-        poll_interval_seconds: int,
-        max_wait_seconds: int,
-    ) -> None:
-        status_url = f"{self.api_url}/clinic/dataexport/status"
-        deadline = time.monotonic() + max_wait_seconds
-        attempt = 0
-
-        while True:
-            attempt += 1
-            response = self._request_with_auth(
-                "GET",
-                status_url,
-                "check export status",
-                params={"exportId": export_id},
-            )
-            self._raise_for_status("check export status", status_url, response)
-
-            payload = response.json()
-            if not isinstance(payload, dict):
-                raise RuntimeError("Export status response was not a JSON object.")
-
-            status = payload.get("exportStatus")
-            LOGGER.info("Export %s status on poll %s: %s", export_id, attempt, status)
-
-            if status == "Ready":
-                return
-            if status in {"Error", "Failed"}:
-                raise RuntimeError(f"Export {export_id} failed: {payload}")
-
-            remaining_seconds = deadline - time.monotonic()
-            if remaining_seconds <= 0:
-                raise TimeoutError(
-                    f"Export {export_id} did not reach Ready within {max_wait_seconds} seconds."
-                )
-
-            time.sleep(min(poll_interval_seconds, max(1, int(remaining_seconds))))
-
-    def download_export(self, export_id: str) -> tuple[str, bytes]:
-        download_url = f"{self.api_url}/clinic/dataexport/download"
-        response = self._request_with_auth(
-            "GET",
-            download_url,
-            "download export",
-            params={"exportId": export_id},
-        )
-        self._raise_for_status("download export", download_url, response)
-
-        filename = extract_filename(response.headers.get("Content-Disposition"), export_id)
-        return filename, response.content
-
-
-def download_and_save_export(
-    *,
-    client: ViedocExportClient,
-    export_id: str,
-    output_dir: Path,
-    extract_zip: bool,
-    remove_prefix: bool,
-) -> Path:
-    filename, content = client.download_export(export_id)
-    output_dir.mkdir(parents=True, exist_ok=True)
-
-    if extract_zip and filename.lower().endswith(".zip"):
-        LOGGER.info("Extracting %s into %s", filename, output_dir)
-        with zipfile.ZipFile(io.BytesIO(content)) as archive:
-            archive_members = archive.namelist()
-            archive.extractall(output_dir)
+        # Remove the prefix from the extracted files if required
         if remove_prefix:
-            remove_extracted_prefix(output_dir, Path(filename).stem, archive_members)
-        LOGGER.info("Export extracted successfully into %s", output_dir)
-        return output_dir
+            zip_filename_without_extension = os.path.splitext(filename)[0]
+            extracted_files = os.listdir(folder_path)
 
-    target_path = output_dir / filename
-    target_path.write_bytes(content)
-    LOGGER.info("Export saved to %s", target_path)
-    return target_path
+            for file in extracted_files:
+                if file.startswith(zip_filename_without_extension):
+                    new_filename = file[len(zip_filename_without_extension):].lstrip("_")
+                    new_file_path = os.path.join(folder_path, new_filename)
+                    if os.path.exists(new_file_path):
+                        os.remove(new_file_path)
+                    os.rename(os.path.join(folder_path, file), new_file_path)
+        return
+    else:
+        # Save the file to out/filename
+        with open(os.path.join(folder_path, filename), "wb") as f:
+            f.write(response.content)
 
+def main(token_url, api_url, client_id, client_secret, export_model, extract_zip, remove_prefix):
+    """
+    Main function to execute the export process.
 
-def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Download a single Viedoc export.")
-    parser.add_argument("--token_url", required=True, help="OAuth token endpoint URL")
-    parser.add_argument("--api_url", required=True, help="Base Viedoc Web API URL")
-    parser.add_argument("--client_id", required=True, help="API client ID")
-    parser.add_argument("--client_secret", required=True, help="API client secret")
-    parser.add_argument(
-        "--export_model",
-        required=True,
-        help="Inline JSON, a JSON file path, or @path/to/export_model.json",
-    )
-    parser.add_argument(
-        "--output_path",
-        "--output_dir",
-        dest="output_dir",
-        default=str(DEFAULT_OUTPUT_DIR),
-        help="Directory where the export file or extracted files will be written",
-    )
-    parser.add_argument(
-        "--extract_zip",
-        default="Y",
-        choices=["Y", "N"],
-        help="Extract zip exports after download (default: Y)",
-    )
-    parser.add_argument(
-        "--remove_prefix",
-        default="Y",
-        choices=["Y", "N"],
-        help="Remove the zip filename prefix from extracted items when possible (default: Y)",
-    )
-    parser.add_argument(
-        "--timeout_seconds",
-        type=int,
-        default=DEFAULT_TIMEOUT_SECONDS,
-        help=f"HTTP timeout per request in seconds (default: {DEFAULT_TIMEOUT_SECONDS})",
-    )
-    parser.add_argument(
-        "--poll_interval_seconds",
-        type=int,
-        default=DEFAULT_POLL_INTERVAL_SECONDS,
-        help=f"Seconds between export status checks (default: {DEFAULT_POLL_INTERVAL_SECONDS})",
-    )
-    parser.add_argument(
-        "--max_wait_seconds",
-        type=int,
-        default=DEFAULT_MAX_WAIT_SECONDS,
-        help=f"Maximum total wait time for export readiness (default: {DEFAULT_MAX_WAIT_SECONDS})",
-    )
-    parser.add_argument(
-        "--log_level",
-        default="INFO",
-        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
-        help="Logging verbosity (default: INFO)",
-    )
-    return parser
+    Args:
+    - token_url (str): URL to get the token.
+    - api_url (str): Base API URL.
+    - client_id (str): Client ID for authentication.
+    - client_secret (str): Client secret for authentication.
+    - export_model (str): JSON string representing the export model.
+    - extract_zip (bool): Whether to extract the zip file.
+    - remove_prefix (bool): Whether to remove the prefix from extracted files.
+    
+    Example export mode:
+    {"outputFormat":"CSV","includeVisitDates":true,"includeEditStatus":true,"includeSignatures":true,"includeReviewStatus":true,"includeSdv":true,"includeQueries":true,"includeQueryHistory":true,"includeSubjectStatus":true,"includePendingForms":true}"
+    """
+    logging.info("ViedocExport@1")
 
+    start_export_url = api_url + "/clinic/dataexport/start"
+    check_status_url = api_url + "/clinic/dataexport/status"
+    download_url = api_url + "/clinic/dataexport/download"
 
-def validate_positive_integer(name: str, value: int) -> None:
-    if value <= 0:
-        raise ValueError(f"{name} must be greater than 0.")
+    logging.info("Token URL: %s", token_url)
+    logging.info("Start export URL: %s", start_export_url)
+    logging.info("Check status URL: %s", check_status_url)
+    logging.info("Download URL: %s", download_url)
 
+    # Log only the first 3 characters of the client_id and client_secret for security
+    logging.info("Client ID: %s", client_id[:3] + '*' * (len(client_id) - 3))
+    logging.info("Client secret: %s", client_secret[:3] + '*' * (len(client_secret) - 3))
+    
+    # Load export model from file if needed
+    export_model = load_export_model(export_model)
+    logging.info("Export model: %s", export_model)
+    
+    # Get the access token
+    token = get_token(token_url, client_id, client_secret)
 
-def ensure_requests_available() -> None:
-    if REQUESTS_IMPORT_ERROR is not None:
-        raise SystemExit(
-            "Missing dependency: requests. Install it with `pip install requests` and rerun."
-        )
+    # Start the export process
+    export_id = start_export(start_export_url, token, export_model)
+    logging.info("Export ID: %s", export_id)
 
-
-def main() -> int:
-    parser = build_parser()
-    args = parser.parse_args()
-
-    configure_logging(args.log_level)
-    ensure_requests_available()
-    validate_positive_integer("timeout_seconds", args.timeout_seconds)
-    validate_positive_integer("poll_interval_seconds", args.poll_interval_seconds)
-    validate_positive_integer("max_wait_seconds", args.max_wait_seconds)
-
-    export_model = parse_export_model(args.export_model)
-    output_dir = Path(args.output_dir).expanduser()
-
-    LOGGER.info("ViedocExport@2")
-    LOGGER.info("Token URL: %s", args.token_url)
-    LOGGER.info("API URL: %s", args.api_url.rstrip("/"))
-    LOGGER.info("Output directory: %s", output_dir)
-    LOGGER.info("Client ID: %s", mask_value(args.client_id))
-    LOGGER.info("Client secret: %s", mask_value(args.client_secret))
-    LOGGER.info("Export model: %s", json.dumps(export_model, separators=(",", ":")))
-
-    client = ViedocExportClient(
-        token_url=args.token_url,
-        api_url=args.api_url,
-        client_id=args.client_id,
-        client_secret=args.client_secret,
-        timeout_seconds=args.timeout_seconds,
-    )
-
-    export_id = client.start_export(export_model)
-    LOGGER.info("Export ID: %s", export_id)
-    client.wait_for_export(
-        export_id,
-        poll_interval_seconds=args.poll_interval_seconds,
-        max_wait_seconds=args.max_wait_seconds,
-    )
-
-    final_path = download_and_save_export(
-        client=client,
-        export_id=export_id,
-        output_dir=output_dir,
-        extract_zip=args.extract_zip == "Y",
-        remove_prefix=args.remove_prefix == "Y",
-    )
-    LOGGER.info("Completed export. Output: %s", final_path)
-    return 0
-
+    # Check the export status until it's ready
+    check_export_status(check_status_url, token, export_id)
+    
+    # Download the export file
+    download_export(download_url, token, export_id, extract_zip, remove_prefix)
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    parser = argparse.ArgumentParser(description="Viedoc export script")
+    
+    # Define command-line arguments
+    parser.add_argument("--token_url", required=True, help="Token URL")
+    parser.add_argument("--api_url", required=True, help="API URL")
+    parser.add_argument("--client_id", required=True, help="Client ID")
+    parser.add_argument("--client_secret", required=True, help="Client secret")
+    parser.add_argument("--export_model", required=True, help="Inline JSON or a file path starting with @ (e.g., @export_model.json)")
+    parser.add_argument("--extract_zip", required=False, default="Y", choices=["Y", "N"], help="Extract zip file (Y/N)")
+    parser.add_argument("--remove_prefix", required=False, default="Y", choices=["Y", "N"], help="Remove prefix from extracted files (Y/N)")
+
+    args = parser.parse_args()
+
+    # Call the main function with parsed arguments
+    main(args.token_url, args.api_url, args.client_id, args.client_secret, args.export_model, args.extract_zip == "Y", args.remove_prefix == "Y")

--- a/viedoc-export/viedoc_export.py
+++ b/viedoc-export/viedoc_export.py
@@ -1,195 +1,439 @@
-import argparse  # For parsing command-line arguments
-import io  # For handling byte streams
-import zipfile  # For handling zip files
-import requests  # For making HTTP requests
-import time  # For adding delays
-import re  # For regular expression operations
-import os  # For file and directory operations
-import logging  # For logging information
+"""Single-study Viedoc data export helper."""
 
-# Configure logging to display info messages with a specific format
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+from __future__ import annotations
 
-def get_token(url, client_id, client_secret):
-    """
-    Request an access token from the authentication server.
-    
-    Args:
-    - url (str): URL to get the token from.
-    - client_id (str): Client ID for authentication.
-    - client_secret (str): Client secret for authentication.
-    
-    Returns:
-    - str: Access token.
-    """
-    logging.info("Getting token...")
-    payload = {
-        "grant_type": "client_credentials",
-        "client_id": client_id,
-        "client_secret": client_secret
-    }
-    response = requests.post(url, data=payload)
-    response.raise_for_status()  # Raise an exception for HTTP errors
-    return response.json()["access_token"]
+import argparse
+import io
+import json
+import logging
+import shutil
+import time
+import urllib.parse
+import zipfile
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
-def start_export(url, token, export_model):
-    """
-    Start the export process.
+if TYPE_CHECKING:
+    import requests as requests_module
 
-    Args:
-    - url (str): URL to start the export.
-    - token (str): Access token for authorization.
-    - export_model (str): JSON string representing the export model.
-    
-    Returns:
-    - str: Export ID.
-    """
-    logging.info("Starting export...")
-    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
-    response = requests.post(url, headers=headers, data=export_model)
-    
-    if response.status_code > 399:
-        logging.info("Error: %s", response.text)
-        response.raise_for_status()  # Raise an exception for HTTP errors
-    
-    return response.json()["exportId"]
+try:
+    import requests
+except ImportError as exc:  # pragma: no cover - dependency validation only
+    requests = None  # type: ignore[assignment]
+    REQUESTS_IMPORT_ERROR = exc
+else:
+    REQUESTS_IMPORT_ERROR = None
 
-def check_export_status(url, token, export_id):
-    """
-    Check the status of the export until it's ready.
 
-    Args:
-    - url (str): URL to check the export status.
-    - token (str): Access token for authorization.
-    - export_id (str): ID of the export to check.
-    """
-    logging.info("Checking export status...")
-    headers = {"Authorization": f"Bearer {token}"}
-    while True:
-        response = requests.get(f"{url}?exportId={export_id}", headers=headers)
-        response.raise_for_status()  # Raise an exception for HTTP errors
-        status = response.json()["exportStatus"]
+LOGGER = logging.getLogger("viedoc_export")
+DEFAULT_OUTPUT_DIR = Path("out")
+DEFAULT_TIMEOUT_SECONDS = 60
+DEFAULT_POLL_INTERVAL_SECONDS = 10
+DEFAULT_MAX_WAIT_SECONDS = 600
 
-        logging.info("Export status: %s", status)
 
-        if status == "Error":
-            raise Exception("Export failed")  # Raise an exception if the export failed
+def configure_logging(level: str) -> None:
+    logging.basicConfig(
+        level=getattr(logging, level.upper(), logging.INFO),
+        format="%(asctime)s - %(levelname)s - %(message)s",
+    )
 
-        if status == "Ready":
-            return  # Exit the loop if the export is ready
-        logging.info("Sleeping...")
-        time.sleep(10)  # Wait for 10 seconds before checking again
 
-def download_export(url, token, export_id, extract_zip, remove_prefix):
-    """
-    Download the export file and optionally extract it.
+def mask_value(value: str, visible_prefix: int = 3) -> str:
+    if not value:
+        return "***"
+    if len(value) <= visible_prefix:
+        return "*" * len(value)
+    return value[:visible_prefix] + "*" * (len(value) - visible_prefix)
 
-    Args:
-    - url (str): URL to download the export.
-    - token (str): Access token for authorization.
-    - export_id (str): ID of the export to download.
-    - extract_zip (bool): Whether to extract the zip file.
-    - remove_prefix (bool): Whether to remove the prefix from extracted files.
-    """
-    headers = {"Authorization": f"Bearer {token}"}
-    response = requests.get(f"{url}?exportId={export_id}", headers=headers)
-    response.raise_for_status()  # Raise an exception for HTTP errors
 
-    # Extract the filename from the Content-Disposition header
-    content_disposition_header = response.headers.get("Content-Disposition")
-    filename = re.search("filename=(.+)", content_disposition_header).group(1)
+def parse_export_model(raw_value: str) -> dict[str, Any]:
+    candidate = raw_value.strip()
+    file_path_text = candidate[1:] if candidate.startswith("@") else candidate
+    file_path = Path(file_path_text)
 
-    # Create the 'out' folder if it doesn't exist
-    if not os.path.exists("out"):
-        os.makedirs("out")
-
-    folder_path = "out"
-
-    logging.info("Folder path: %s", folder_path)
-
-    # If the filename is .zip and extract_zip is True, extract the file
-    if filename.endswith(".zip") and extract_zip:
-        logging.info("Extracting zip file...")
-        with zipfile.ZipFile(io.BytesIO(response.content)) as z:
-            z.extractall(folder_path)
-        logging.info("File extracted successfully!")
-
-        # Remove the prefix from the extracted files if required
-        if remove_prefix:
-            zip_filename_without_extension = os.path.splitext(filename)[0]
-            extracted_files = os.listdir(folder_path)
-
-            for file in extracted_files:
-                if file.startswith(zip_filename_without_extension):
-                    new_filename = file[len(zip_filename_without_extension):].lstrip("_")
-                    new_file_path = os.path.join(folder_path, new_filename)
-                    if os.path.exists(new_file_path):
-                        os.remove(new_file_path)
-                    os.rename(os.path.join(folder_path, file), new_file_path)
-        return
+    if file_path.is_file():
+        LOGGER.info("Reading export model from %s", file_path)
+        content = file_path.read_text(encoding="utf-8")
     else:
-        # Save the file to out/filename
-        with open(os.path.join(folder_path, filename), "wb") as f:
-            f.write(response.content)
+        content = candidate
 
-def main(token_url, api_url, client_id, client_secret, export_model, extract_zip, remove_prefix):
-    """
-    Main function to execute the export process.
+    try:
+        parsed = json.loads(content)
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            "Invalid export model JSON. Pass inline JSON or a path to a JSON file."
+        ) from exc
 
-    Args:
-    - token_url (str): URL to get the token.
-    - api_url (str): Base API URL.
-    - client_id (str): Client ID for authentication.
-    - client_secret (str): Client secret for authentication.
-    - export_model (str): JSON string representing the export model.
-    - extract_zip (bool): Whether to extract the zip file.
-    - remove_prefix (bool): Whether to remove the prefix from extracted files.
-    
-    Example export mode:
-    {"outputFormat":"CSV","includeVisitDates":true,"includeEditStatus":true,"includeSignatures":true,"includeReviewStatus":true,"includeSdv":true,"includeQueries":true,"includeQueryHistory":true,"includeSubjectStatus":true,"includePendingForms":true}"
-    """
-    logging.info("ViedocExport@1")
+    if not isinstance(parsed, dict):
+        raise ValueError("The export model must decode to a JSON object.")
 
-    start_export_url = api_url + "/clinic/dataexport/start"
-    check_status_url = api_url + "/clinic/dataexport/status"
-    download_url = api_url + "/clinic/dataexport/download"
+    return parsed
 
-    logging.info("Token URL: %s", token_url)
-    logging.info("Start export URL: %s", start_export_url)
-    logging.info("Check status URL: %s", check_status_url)
-    logging.info("Download URL: %s", download_url)
 
-    # Log only the first 3 characters of the client_id and client_secret for security
-    logging.info("Client ID: %s", client_id[:3] + '*' * (len(client_id) - 3))
-    logging.info("Client secret: %s", client_secret[:3] + '*' * (len(client_secret) - 3))
-    logging.info("Export model: %s", export_model)
-    
-    # Get the access token
-    token = get_token(token_url, client_id, client_secret)
+def extract_filename(content_disposition: str | None, export_id: str) -> str:
+    if not content_disposition:
+        return f"viedoc_export_{export_id}"
 
-    # Start the export process
-    export_id = start_export(start_export_url, token, export_model)
-    logging.info("Export ID: %s", export_id)
+    filename_star = "filename*="
+    if filename_star in content_disposition:
+        fragment = content_disposition.split(filename_star, 1)[1].split(";", 1)[0].strip()
+        if "''" in fragment:
+            _, encoded_name = fragment.split("''", 1)
+        else:
+            encoded_name = fragment
+        decoded_name = urllib.parse.unquote(encoded_name.strip('"'))
+        if decoded_name:
+            return Path(decoded_name).name
 
-    # Check the export status until it's ready
-    check_export_status(check_status_url, token, export_id)
-    
-    # Download the export file
-    download_export(download_url, token, export_id, extract_zip, remove_prefix)
+    filename_key = "filename="
+    if filename_key in content_disposition:
+        fragment = content_disposition.split(filename_key, 1)[1].split(";", 1)[0].strip()
+        decoded_name = fragment.strip('"')
+        if decoded_name:
+            return Path(decoded_name).name
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Viedoc export script")
-    
-    # Define command-line arguments
-    parser.add_argument("--token_url", required=True, help="Token URL")
-    parser.add_argument("--api_url", required=True, help="API URL")
-    parser.add_argument("--client_id", required=True, help="Client ID")
-    parser.add_argument("--client_secret", required=True, help="Client secret")
-    parser.add_argument("--export_model", required=True, help="Export model")
-    parser.add_argument("--extract_zip", required=False, default="Y", choices=["Y", "N"], help="Extract zip file (Y/N)")
-    parser.add_argument("--remove_prefix", required=False, default="Y", choices=["Y", "N"], help="Remove prefix from extracted files (Y/N)")
+    return f"viedoc_export_{export_id}"
 
+
+def move_path_contents(source_dir: Path, destination_dir: Path) -> None:
+    for child in source_dir.iterdir():
+        target = destination_dir / child.name
+        if target.exists():
+            if target.is_dir():
+                shutil.rmtree(target)
+            else:
+                target.unlink()
+        shutil.move(str(child), str(target))
+    source_dir.rmdir()
+
+
+def remove_extracted_prefix(output_dir: Path, zip_stem: str, archive_members: list[str]) -> None:
+    if not zip_stem:
+        return
+
+    top_level_members = {
+        Path(member).parts[0]
+        for member in archive_members
+        if member and not member.endswith("/")
+    }
+
+    for member_name in sorted(top_level_members, key=len, reverse=True):
+        source = output_dir / member_name
+        if not source.exists():
+            continue
+
+        if member_name == zip_stem and source.is_dir():
+            move_path_contents(source, output_dir)
+            continue
+
+        if not member_name.startswith(zip_stem):
+            continue
+
+        trimmed_name = member_name[len(zip_stem) :].lstrip(" _-.")
+        if not trimmed_name:
+            continue
+
+        target = output_dir / trimmed_name
+        if target.exists():
+            if target.is_dir():
+                shutil.rmtree(target)
+            else:
+                target.unlink()
+        source.replace(target)
+
+
+class ViedocExportClient:
+    def __init__(
+        self,
+        *,
+        token_url: str,
+        api_url: str,
+        client_id: str,
+        client_secret: str,
+        timeout_seconds: int,
+    ) -> None:
+        self.token_url = token_url
+        self.api_url = api_url.rstrip("/")
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.timeout_seconds = timeout_seconds
+        self.session = requests.Session()
+        self._token: str | None = None
+
+    def _fetch_token(self) -> str:
+        LOGGER.info("Requesting access token from %s", self.token_url)
+        response = self.session.post(
+            self.token_url,
+            data={
+                "grant_type": "client_credentials",
+                "client_id": self.client_id,
+                "client_secret": self.client_secret,
+            },
+            timeout=self.timeout_seconds,
+        )
+        self._raise_for_status("token request", self.token_url, response)
+
+        payload = response.json()
+        token = payload.get("access_token") if isinstance(payload, dict) else None
+        if not token:
+            raise RuntimeError("Token response did not include 'access_token'.")
+
+        self._token = str(token)
+        return self._token
+
+    def _request_with_auth(
+        self,
+        method: str,
+        url: str,
+        action: str,
+        **kwargs: Any,
+    ) -> "requests_module.Response":
+        for attempt in (1, 2):
+            token = self._token or self._fetch_token()
+            headers = dict(kwargs.pop("headers", {}))
+            headers["Authorization"] = f"Bearer {token}"
+            response = self.session.request(
+                method,
+                url,
+                headers=headers,
+                timeout=self.timeout_seconds,
+                **kwargs,
+            )
+            if response.status_code != 401 or attempt == 2:
+                return response
+
+            LOGGER.warning("%s returned 401. Refreshing token and retrying once.", action)
+            self._token = None
+
+        raise RuntimeError("Unreachable auth retry state.")
+
+    @staticmethod
+    def _raise_for_status(action: str, url: str, response: "requests_module.Response") -> None:
+        try:
+            response.raise_for_status()
+        except requests.HTTPError as exc:
+            details = response.text.strip()
+            raise RuntimeError(
+                f"{action} failed for {url} with status {response.status_code}: {details}"
+            ) from exc
+
+    def start_export(self, export_model: dict[str, Any]) -> str:
+        url = f"{self.api_url}/clinic/dataexport/start"
+        LOGGER.info("Starting export at %s", url)
+        response = self._request_with_auth(
+            "POST",
+            url,
+            "start export",
+            headers={"Content-Type": "application/json"},
+            json=export_model,
+        )
+        self._raise_for_status("start export", url, response)
+
+        payload = response.json()
+        export_id = payload.get("exportId") if isinstance(payload, dict) else None
+        if not export_id:
+            raise RuntimeError("Export start response did not include 'exportId'.")
+        return str(export_id)
+
+    def wait_for_export(
+        self,
+        export_id: str,
+        *,
+        poll_interval_seconds: int,
+        max_wait_seconds: int,
+    ) -> None:
+        status_url = f"{self.api_url}/clinic/dataexport/status"
+        deadline = time.monotonic() + max_wait_seconds
+        attempt = 0
+
+        while True:
+            attempt += 1
+            response = self._request_with_auth(
+                "GET",
+                status_url,
+                "check export status",
+                params={"exportId": export_id},
+            )
+            self._raise_for_status("check export status", status_url, response)
+
+            payload = response.json()
+            if not isinstance(payload, dict):
+                raise RuntimeError("Export status response was not a JSON object.")
+
+            status = payload.get("exportStatus")
+            LOGGER.info("Export %s status on poll %s: %s", export_id, attempt, status)
+
+            if status == "Ready":
+                return
+            if status in {"Error", "Failed"}:
+                raise RuntimeError(f"Export {export_id} failed: {payload}")
+
+            remaining_seconds = deadline - time.monotonic()
+            if remaining_seconds <= 0:
+                raise TimeoutError(
+                    f"Export {export_id} did not reach Ready within {max_wait_seconds} seconds."
+                )
+
+            time.sleep(min(poll_interval_seconds, max(1, int(remaining_seconds))))
+
+    def download_export(self, export_id: str) -> tuple[str, bytes]:
+        download_url = f"{self.api_url}/clinic/dataexport/download"
+        response = self._request_with_auth(
+            "GET",
+            download_url,
+            "download export",
+            params={"exportId": export_id},
+        )
+        self._raise_for_status("download export", download_url, response)
+
+        filename = extract_filename(response.headers.get("Content-Disposition"), export_id)
+        return filename, response.content
+
+
+def download_and_save_export(
+    *,
+    client: ViedocExportClient,
+    export_id: str,
+    output_dir: Path,
+    extract_zip: bool,
+    remove_prefix: bool,
+) -> Path:
+    filename, content = client.download_export(export_id)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    if extract_zip and filename.lower().endswith(".zip"):
+        LOGGER.info("Extracting %s into %s", filename, output_dir)
+        with zipfile.ZipFile(io.BytesIO(content)) as archive:
+            archive_members = archive.namelist()
+            archive.extractall(output_dir)
+        if remove_prefix:
+            remove_extracted_prefix(output_dir, Path(filename).stem, archive_members)
+        LOGGER.info("Export extracted successfully into %s", output_dir)
+        return output_dir
+
+    target_path = output_dir / filename
+    target_path.write_bytes(content)
+    LOGGER.info("Export saved to %s", target_path)
+    return target_path
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Download a single Viedoc export.")
+    parser.add_argument("--token_url", required=True, help="OAuth token endpoint URL")
+    parser.add_argument("--api_url", required=True, help="Base Viedoc Web API URL")
+    parser.add_argument("--client_id", required=True, help="API client ID")
+    parser.add_argument("--client_secret", required=True, help="API client secret")
+    parser.add_argument(
+        "--export_model",
+        required=True,
+        help="Inline JSON, a JSON file path, or @path/to/export_model.json",
+    )
+    parser.add_argument(
+        "--output_path",
+        "--output_dir",
+        dest="output_dir",
+        default=str(DEFAULT_OUTPUT_DIR),
+        help="Directory where the export file or extracted files will be written",
+    )
+    parser.add_argument(
+        "--extract_zip",
+        default="Y",
+        choices=["Y", "N"],
+        help="Extract zip exports after download (default: Y)",
+    )
+    parser.add_argument(
+        "--remove_prefix",
+        default="Y",
+        choices=["Y", "N"],
+        help="Remove the zip filename prefix from extracted items when possible (default: Y)",
+    )
+    parser.add_argument(
+        "--timeout_seconds",
+        type=int,
+        default=DEFAULT_TIMEOUT_SECONDS,
+        help=f"HTTP timeout per request in seconds (default: {DEFAULT_TIMEOUT_SECONDS})",
+    )
+    parser.add_argument(
+        "--poll_interval_seconds",
+        type=int,
+        default=DEFAULT_POLL_INTERVAL_SECONDS,
+        help=f"Seconds between export status checks (default: {DEFAULT_POLL_INTERVAL_SECONDS})",
+    )
+    parser.add_argument(
+        "--max_wait_seconds",
+        type=int,
+        default=DEFAULT_MAX_WAIT_SECONDS,
+        help=f"Maximum total wait time for export readiness (default: {DEFAULT_MAX_WAIT_SECONDS})",
+    )
+    parser.add_argument(
+        "--log_level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        help="Logging verbosity (default: INFO)",
+    )
+    return parser
+
+
+def validate_positive_integer(name: str, value: int) -> None:
+    if value <= 0:
+        raise ValueError(f"{name} must be greater than 0.")
+
+
+def ensure_requests_available() -> None:
+    if REQUESTS_IMPORT_ERROR is not None:
+        raise SystemExit(
+            "Missing dependency: requests. Install it with `pip install requests` and rerun."
+        )
+
+
+def main() -> int:
+    parser = build_parser()
     args = parser.parse_args()
 
-    # Call the main function with parsed arguments
-    main(args.token_url, args.api_url, args.client_id, args.client_secret, args.export_model, args.extract_zip == "Y", args.remove_prefix == "Y")
+    configure_logging(args.log_level)
+    ensure_requests_available()
+    validate_positive_integer("timeout_seconds", args.timeout_seconds)
+    validate_positive_integer("poll_interval_seconds", args.poll_interval_seconds)
+    validate_positive_integer("max_wait_seconds", args.max_wait_seconds)
+
+    export_model = parse_export_model(args.export_model)
+    output_dir = Path(args.output_dir).expanduser()
+
+    LOGGER.info("ViedocExport@2")
+    LOGGER.info("Token URL: %s", args.token_url)
+    LOGGER.info("API URL: %s", args.api_url.rstrip("/"))
+    LOGGER.info("Output directory: %s", output_dir)
+    LOGGER.info("Client ID: %s", mask_value(args.client_id))
+    LOGGER.info("Client secret: %s", mask_value(args.client_secret))
+    LOGGER.info("Export model: %s", json.dumps(export_model, separators=(",", ":")))
+
+    client = ViedocExportClient(
+        token_url=args.token_url,
+        api_url=args.api_url,
+        client_id=args.client_id,
+        client_secret=args.client_secret,
+        timeout_seconds=args.timeout_seconds,
+    )
+
+    export_id = client.start_export(export_model)
+    LOGGER.info("Export ID: %s", export_id)
+    client.wait_for_export(
+        export_id,
+        poll_interval_seconds=args.poll_interval_seconds,
+        max_wait_seconds=args.max_wait_seconds,
+    )
+
+    final_path = download_and_save_export(
+        client=client,
+        export_id=export_id,
+        output_dir=output_dir,
+        extract_zip=args.extract_zip == "Y",
+        remove_prefix=args.remove_prefix == "Y",
+    )
+    LOGGER.info("Completed export. Output: %s", final_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Changes

### 1. Filename extraction hardening

- Replace greedy regex `filename=(.+)` with split-based parsing
- Fixes edge case where Content-Disposition headers include multiple filename variants (RFC 5987)
- Previously failed when server returned: `filename="DEMO_STUDY-_20260409_095511.zip"; filename*=UTF-8''DEMO_STUDY-_20260409_095511.zip`
- Now correctly extracts just the filename before the semicolon

### 2. JSON file support

- Add `load_export_model()` function to support specifying export model via file
- Syntax: `--export_model path/to/export_model.json` : uses `.json` suffix to ID paths
- Avoids shell-specific quoting issues across Windows, macOS, and Linux
- inline JSON still supported: `--export_model '{"outputFormat":"CSV"}'`

### 3. Documentation updates

- Added platform-specific shell quoting guide (bash/zsh, PowerShell, cmd.exe)
- Recommends JSON file approach as safest cross-platform method
  
## Testing
- powershell and cmd.exe examples in README.md were tested with and without file path specification, and with inline specification